### PR TITLE
Restrict size of bitmap in FastBitmapDrawable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=2.2.4-bandlab-fix-v2
+VERSION_NAME=2.2.4-bandlab-fix-v3
 VERSION_CODE=24
 GROUP=com.github.yalantis
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/util/FastBitmapDrawable.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/util/FastBitmapDrawable.java
@@ -30,9 +30,24 @@ public class FastBitmapDrawable extends Drawable {
     private int mAlpha;
     private int mWidth, mHeight;
 
-    public FastBitmapDrawable(Bitmap b) {
+    public FastBitmapDrawable(Bitmap b, int maxWidth, int maxHeight) {
         mAlpha = 255;
-        setBitmap(b);
+
+        float scale = Math.min(1.0f, (float) maxWidth / b.getWidth());
+        scale = Math.min(scale, (float) maxHeight / b.getHeight());
+
+        Bitmap bitmap;
+        if (scale < 1.0f) {
+            bitmap = Bitmap.createScaledBitmap(
+                    b,
+                    (int) (b.getWidth() * scale),
+                    (int) (b.getHeight() * scale),
+                    false
+            );
+        } else {
+            bitmap = b;
+        }
+        setBitmap(bitmap);
     }
 
     @Override

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
@@ -7,6 +7,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.yalantis.ucrop.callback.BitmapLoadCallback;
@@ -33,6 +34,7 @@ public class TransformImageView extends AppCompatImageView {
     private static final int RECT_CORNER_POINTS_COORDS = 8;
     private static final int RECT_CENTER_POINT_COORDS = 2;
     private static final int MATRIX_VALUES_COUNT = 9;
+    private static final int BITMAP_SCALE = 2;
 
     protected final float[] mCurrentImageCorners = new float[RECT_CORNER_POINTS_COORDS];
     protected final float[] mCurrentImageCenter = new float[RECT_CENTER_POINT_COORDS];
@@ -115,7 +117,12 @@ public class TransformImageView extends AppCompatImageView {
 
     @Override
     public void setImageBitmap(final Bitmap bitmap) {
-        setImageDrawable(new FastBitmapDrawable(bitmap));
+        DisplayMetrics dm = getResources().getDisplayMetrics();
+        setImageDrawable(new FastBitmapDrawable(
+                bitmap,
+                dm.widthPixels * BITMAP_SCALE,
+                dm.heightPixels * BITMAP_SCALE
+        ));
     }
 
     public String getImageInputPath() {


### PR DESCRIPTION
Restrict size of bitmap that is using in FastBitmapDrawable with double size of screen, so. we should avoid exception in `FastBitmapDrawable.draw` cause our bitmap is too big to render